### PR TITLE
Create a Exam domain

### DIFF
--- a/src/modules/exam/dtos/ICreateExamDTO.ts
+++ b/src/modules/exam/dtos/ICreateExamDTO.ts
@@ -1,0 +1,8 @@
+interface ICreateExamDTO {
+    cpf: string;
+    exam: string;
+    doctor_name: string;
+    scheduled_at: Date;
+};
+
+export default ICreateExamDTO;

--- a/src/modules/exam/dtos/IDeleteExamDTO.ts
+++ b/src/modules/exam/dtos/IDeleteExamDTO.ts
@@ -1,0 +1,5 @@
+interface IDeleteExamDTO {
+    cpf: string;
+};
+
+export default IDeleteExamDTO;

--- a/src/modules/exam/infra/http/controllers/ExamController.ts
+++ b/src/modules/exam/infra/http/controllers/ExamController.ts
@@ -1,0 +1,57 @@
+import { container } from 'tsyringe';
+
+import { Request, Response } from 'express';
+
+import CreateExamService from '../../../services/CreateExamService';
+import DeleteExamService from '../../../services/DeleteExamService';
+import ShowExamService from '../../../services/ShowExamService';
+import ListExamsService from '../../../services/ListExamsService';
+
+class ExamController {
+    public async create(request: Request, response: Response): Promise<Response> {
+        const { cpf, exam, doctor_name, scheduled_at } = request.body;
+
+        const createExam = container.resolve(CreateExamService);
+
+        const patientExam = await createExam.execute({
+            cpf,
+            exam,
+            doctor_name,
+            scheduled_at,
+        });
+
+        return response.json(patientExam);
+    };
+
+    public async delete(request: Request, response: Response): Promise<Response> {
+        const { cpf } = request.params;
+
+        const deletePatient = container.resolve(DeleteExamService);
+
+        await deletePatient.execute({ cpf });
+
+        return response.json({
+            message: 'The exam was canceled with successful.',
+        });
+    };
+
+    public async index(_: Request, response: Response): Promise<Response> {
+        const listExams = container.resolve(ListExamsService);
+
+        const exams = await listExams.execute();
+
+        return response.json(exams);
+    };
+
+    public async show(request: Request, response: Response): Promise<Response> {
+        const { cpf } = request.params;
+
+        const showExam = container.resolve(ShowExamService);
+
+        const exam = await showExam.execute({ cpf });
+
+        return response.json(exam);
+    };
+};
+
+export default ExamController;

--- a/src/modules/exam/infra/http/routes/Exam.routes.ts
+++ b/src/modules/exam/infra/http/routes/Exam.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+
+import createExamValidator from '../validators/CreateExamValidator';
+import deleteExamValidator from '../validators/DeleteExamValidator';
+import showExamValidator from '../validators/ShowExamValidator';
+
+import ExamController from '../controllers/ExamController';
+
+const examRouter = Router();
+const examController = new ExamController();
+
+examRouter.post('/', createExamValidator, examController.create);
+examRouter.delete('/:cpf', deleteExamValidator, examController.delete);
+examRouter.get('/', examController.index);
+examRouter.get('/:cpf', showExamValidator, examController.show);
+
+export default examRouter;

--- a/src/modules/exam/infra/http/validators/CreateExamValidator.ts
+++ b/src/modules/exam/infra/http/validators/CreateExamValidator.ts
@@ -1,0 +1,10 @@
+import { celebrate, Segments, Joi } from 'celebrate';
+
+export default celebrate({
+    [Segments.BODY]: {
+        cpf: Joi.string().required(),
+        exam: Joi.string().required(),
+        doctor_name: Joi.string().required(),
+        scheduled_at: Joi.date().required(),
+    },
+});

--- a/src/modules/exam/infra/http/validators/DeleteExamValidator.ts
+++ b/src/modules/exam/infra/http/validators/DeleteExamValidator.ts
@@ -1,0 +1,7 @@
+import { celebrate, Segments, Joi } from 'celebrate';
+
+export default celebrate({
+    [Segments.PARAMS]: {
+        cpf: Joi.string().required(),
+    },
+});

--- a/src/modules/exam/infra/http/validators/ShowExamValidator.ts
+++ b/src/modules/exam/infra/http/validators/ShowExamValidator.ts
@@ -1,0 +1,7 @@
+import { celebrate, Segments, Joi } from 'celebrate';
+
+export default celebrate({
+    [Segments.PARAMS]: {
+        cpf: Joi.string().required(),
+    },
+});

--- a/src/modules/exam/infra/typeorm/entities/Exam.ts
+++ b/src/modules/exam/infra/typeorm/entities/Exam.ts
@@ -1,0 +1,41 @@
+import Patient from '../../../../patient/infra/typeorm/entities/Patient';
+
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+    OneToOne,
+    JoinColumn,
+} from 'typeorm';
+
+@Entity('exams')
+class Exam {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column()
+    patient_cpf: string;
+
+    @OneToOne(type => Patient, { primary: true })
+    @JoinColumn({ name: "patient_cpf" })
+    patient: Patient;
+
+    @Column()
+    exam: string;
+
+    @Column()
+    doctor_name: string;
+
+    @Column()
+    scheduled_at: Date;
+
+    @CreateDateColumn()
+    created_at: Date;
+
+    @UpdateDateColumn()
+    updated_at: Date;
+}
+
+export default Exam;

--- a/src/modules/exam/infra/typeorm/repositories/ExamsRepository.ts
+++ b/src/modules/exam/infra/typeorm/repositories/ExamsRepository.ts
@@ -1,0 +1,77 @@
+import AppError from '../../../../../shared/errors/AppError';
+
+import { getRepository, Repository } from 'typeorm';
+
+import ICreateExamDTO from '../../../dtos/ICreateExamDTO';
+import IDeleteExamDTO from '../../../dtos/IDeleteExamDTO';
+
+import IExamRepository from '../../../repositories/IExamsRepository';
+
+import Exam from '../entities/Exam';
+
+class ExamRepository implements IExamRepository {
+    private ormRepository: Repository<Exam>;
+
+    constructor() {
+        this.ormRepository = getRepository(Exam);
+    };
+
+    public async create({
+        cpf,
+        exam,
+        doctor_name,
+        scheduled_at,
+    }: ICreateExamDTO): Promise<Exam> {
+        const patientExam = this.ormRepository.create({
+            patient_cpf: cpf,
+            exam,
+            doctor_name,
+            scheduled_at,
+        });
+
+        await this.ormRepository.save(patientExam);
+
+        return patientExam;
+    };
+
+    public async delete({
+        cpf
+    }: IDeleteExamDTO): Promise<void> {
+        await this.ormRepository.createQueryBuilder()
+            .where("patient_cpf = :patient_cpf", { 
+                patient_cpf: cpf
+            }).delete().execute();
+    };
+
+    public async findAll(): Promise<Exam[]> {
+        const query = this.ormRepository.createQueryBuilder('exams')
+
+        query.orderBy('scheduled_at', 'DESC')
+        query.leftJoinAndSelect("exams.patient", "patients") 
+        query.select([
+            'exams.id', 'exams.patient_cpf', 'exams.exam', 'exams.doctor_name', 'exams.scheduled_at',
+            'patients.name', 'patients.date_of_birth', 'patients.phone_number', 'patients.cep', 'patients.address', 'patients.gender']
+        );
+
+        const exams = await query.getMany();
+    
+        return exams
+    };
+
+    public async findByCpf(cpf: string): Promise<Exam | undefined> {
+        const query = this.ormRepository.createQueryBuilder('exams');
+
+        query.leftJoinAndSelect("exams.patient", "patients");
+        query.select([
+            'exams.id', 'exams.patient_cpf', 'exams.exam', 'exams.doctor_name', 'exams.scheduled_at',
+            'patients.name', 'patients.date_of_birth', 'patients.phone_number', 'patients.cep', 'patients.address', 'patients.gender']
+        );
+        query.where({ patient_cpf: cpf });
+
+        const exam = await query.getOne();
+    
+        return exam
+    };
+}
+
+export default ExamRepository;

--- a/src/modules/exam/repositories/IExamsRepository.ts
+++ b/src/modules/exam/repositories/IExamsRepository.ts
@@ -1,0 +1,13 @@
+import Exam from '../infra/typeorm/entities/Exam';
+
+import IDeleteExamDTO from '../dtos/IDeleteExamDTO';
+import ICreateExamDTO from '../dtos/ICreateExamDTO';
+
+interface IExamsRepository {
+    create(data: ICreateExamDTO): Promise<Exam>;
+    delete(data: IDeleteExamDTO): Promise<void>;
+    findAll(): Promise<Exam[]>;
+    findByCpf(cpf: string): Promise<Exam | undefined>
+}
+
+export default IExamsRepository;

--- a/src/modules/exam/repositories/fakes/FakeExamsRepository.ts
+++ b/src/modules/exam/repositories/fakes/FakeExamsRepository.ts
@@ -1,0 +1,52 @@
+import { v4 } from 'uuid';
+
+import ICreateExamDTO from '../../dtos/ICreateExamDTO';
+import IDeleteExamDTO from '../../dtos/IDeleteExamDTO';
+
+import IExamsRepository from '../IExamsRepository';
+
+import Exam from '../../infra/typeorm/entities/Exam';
+
+class ExamsRepository implements IExamsRepository {
+    private exams: Exam[] = [];
+
+    public async create({
+        cpf,
+        exam,
+        doctor_name,
+        scheduled_at,
+    }: ICreateExamDTO): Promise<Exam> {
+        const patientExam = new Exam();
+
+        Object.assign(patientExam, {
+            id: v4(),
+            patient_cpf: cpf,
+            exam,
+            doctor_name,
+            scheduled_at,
+        });
+
+        this.exams.push(patientExam);
+
+        return patientExam;
+    };
+
+    public async delete({
+        cpf
+    }: IDeleteExamDTO): Promise<void> {
+        const filtered = this.exams.filter(patient => patient.patient_cpf !== cpf);
+        this.exams = filtered;
+    };
+    
+    public async findByCpf(cpf: string): Promise<Exam | undefined> {
+        const patientExam = this.exams.find(patientExam => patientExam.patient_cpf == cpf);
+
+        return patientExam;
+    };
+
+    public async findAll(): Promise<Exam[]> {
+        return this.exams;
+    };
+}
+
+export default ExamsRepository;

--- a/src/modules/exam/services/CreateExamService.ts
+++ b/src/modules/exam/services/CreateExamService.ts
@@ -1,0 +1,40 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from '../../../shared/errors/AppError';
+
+import Exam from '../infra/typeorm/entities/Exam';
+import IExamsRepository from '../repositories/IExamsRepository';
+
+interface IRequest {
+    cpf: string;
+    exam: string;
+    doctor_name: string;
+    scheduled_at: Date;
+}
+
+@injectable()
+class CreateExamService {
+    constructor(
+        @inject('ExamsRepository')
+        private examsRepository: IExamsRepository,
+    ) {}
+
+    public async execute({ cpf, exam, doctor_name, scheduled_at }: IRequest): Promise<Exam> {
+        const checkPatientExam = await this.examsRepository.findByCpf(cpf);
+
+        if (checkPatientExam) {
+            throw new AppError('Exam already scheduled to this patient.');
+        };
+
+        const patientExam = await this.examsRepository.create({
+            cpf,
+            exam,
+            doctor_name,
+            scheduled_at,
+        });
+
+        return patientExam;
+    }
+}
+
+export default CreateExamService;

--- a/src/modules/exam/services/DeleteExamService.ts
+++ b/src/modules/exam/services/DeleteExamService.ts
@@ -1,0 +1,29 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from '../../../shared/errors/AppError';
+
+import IExamsRepository from '../repositories/IExamsRepository';
+
+interface IRequest {
+    cpf: string;
+}
+
+@injectable()
+class DeleteExamService {
+    constructor(
+        @inject('ExamsRepository')
+        private examsRepository: IExamsRepository,
+    ) {}
+
+    public async execute({ cpf }: IRequest): Promise<void> {
+        const checkPatientExam = await this.examsRepository.findByCpf(cpf);
+
+        if (!checkPatientExam) {
+            throw new AppError('Exam isn\'t scheduled to this patient.');
+        };
+
+        await this.examsRepository.delete({ cpf });   
+    }
+}
+
+export default DeleteExamService;

--- a/src/modules/exam/services/ListExamsService.ts
+++ b/src/modules/exam/services/ListExamsService.ts
@@ -1,0 +1,22 @@
+
+import { inject, injectable } from 'tsyringe';
+
+import Exam from '../infra/typeorm/entities/Exam';
+import IExamsRepository from '../repositories/IExamsRepository';
+
+
+@injectable()
+class ListExamsService {
+    constructor(
+        @inject('ExamsRepository')
+        private examsRepository: IExamsRepository,
+    ) {}
+
+    public async execute(): Promise<Exam[] | undefined> {
+        const exams = await this.examsRepository.findAll();
+
+        return exams;
+    }
+}
+
+export default ListExamsService;

--- a/src/modules/exam/services/ShowExamService.ts
+++ b/src/modules/exam/services/ShowExamService.ts
@@ -1,0 +1,30 @@
+import { inject, injectable } from 'tsyringe';
+
+import AppError from '../../../shared/errors/AppError';
+
+import Exam from '../infra/typeorm/entities/Exam';
+import IExamsRepository from '../repositories/IExamsRepository';
+
+interface IRequest {
+    cpf: string;
+}
+
+@injectable()
+class ShowExamService {
+    constructor(
+        @inject('ExamsRepository')
+        private examsRepository: IExamsRepository,
+    ) {}
+
+    public async execute({ cpf }: IRequest): Promise<Exam> {
+        const patientExam = await this.examsRepository.findByCpf(cpf);
+
+        if (!patientExam) {
+            throw new AppError('Exam not scheduled to this person.', 404);
+        }
+
+        return patientExam;
+    };
+}
+
+export default ShowExamService;

--- a/src/modules/exam/services/__tests__/CreateExamService.spec.ts
+++ b/src/modules/exam/services/__tests__/CreateExamService.spec.ts
@@ -1,0 +1,58 @@
+import AppError from '../../../../shared/errors/AppError';
+
+import FakeExamsRepository from '../../repositories/fakes/FakeExamsRepository';
+
+import CreateExamService from '../CreateExamService';
+
+describe('CreateExam', () => {
+    const patient = {
+        name: "Matheus Aragão",
+        date_of_birth: new Date(),
+        phone_number: "81999998888",
+        cpf: "111.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 30, Pinheiros, Recife",
+        gender: 'female'
+    }
+
+    it('should be able to create exam in exams.', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const createExam = new CreateExamService(
+            fakeExamsRepository,
+        );
+
+        const patientInWaitingList = await createExam.execute({
+            cpf: patient.cpf,
+            exam: "Endoscópia",
+            doctor_name: "Drauzio Varela",
+            scheduled_at: new Date(),
+        });
+
+        expect(patientInWaitingList).toHaveProperty('id');
+    });
+
+    it('should not be able to create exam with same CPF in exams.', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const createExam = new CreateExamService(
+            fakeExamsRepository,
+        );
+
+        await createExam.execute({
+            cpf: patient.cpf,
+            exam: "Endoscópia",
+            doctor_name: "Drauzio Varela",
+            scheduled_at: new Date(),
+        });
+        
+        expect(
+            createExam.execute({
+                cpf: patient.cpf,
+                exam: "Hemograma",
+                doctor_name: "Wesley",
+                scheduled_at: new Date(),
+            })
+        ).rejects.toBeInstanceOf(AppError);
+    });
+});

--- a/src/modules/exam/services/__tests__/DeleteExamService.spec.ts
+++ b/src/modules/exam/services/__tests__/DeleteExamService.spec.ts
@@ -1,0 +1,79 @@
+import AppError from '../../../../shared/errors/AppError';
+
+import FakeExamsRepository from '../../repositories/fakes/FakeExamsRepository';
+
+import CreateExamService from '../CreateExamService';
+import ListExamsService from '../ListExamsService';
+import DeleteExamService from '../DeleteExamService';
+
+describe('DeleteExam', () => {
+    const patient1 = {
+        name: "Matheus Aragão",
+        date_of_birth: new Date(),
+        phone_number: "81999998888",
+        cpf: "111.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 30, Pinheiros, Recife",
+        gender: 'female'
+    };
+
+    const patient2 = {
+        name: "Wesley Alves",
+        date_of_birth: new Date(),
+        phone_number: "81988887777",
+        cpf: "22.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 31, Pinheiros, Recife",
+        gender: 'female'
+    };
+
+    it('should be able to delete exam from exams', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const createExam = new CreateExamService(
+            fakeExamsRepository,
+        );
+
+        const deleteExams = new DeleteExamService(
+            fakeExamsRepository,
+        )
+
+        const listExams = new ListExamsService(
+            fakeExamsRepository,
+        );
+
+        await createExam.execute({
+            cpf: patient1.cpf,
+            doctor_name: "JV",
+            exam: "Colonoscopia",
+            scheduled_at: new Date(),
+        });
+
+        await createExam.execute({
+            cpf: patient2.cpf,
+            doctor_name: "Paulo Muzy",
+            exam: "Eletromiografia",
+            scheduled_at: new Date(),
+        });
+
+        const patients1 = await listExams.execute();
+
+        expect(patients1).toHaveLength(2);
+
+        await deleteExams.execute({ cpf: patient2.cpf })
+        
+        const patients2 = await listExams.execute();
+    
+        expect(patients2).toHaveLength(1);
+    });
+
+    it('should not be able to delete exam inexistent.', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const deleteExams = new DeleteExamService(
+            fakeExamsRepository,
+        );
+
+        expect(deleteExams.execute({ cpf: "CPF-INEXISTENTE" })).rejects.toBeInstanceOf(AppError);
+    });
+});

--- a/src/modules/exam/services/__tests__/ListExamsService.spec.ts
+++ b/src/modules/exam/services/__tests__/ListExamsService.spec.ts
@@ -1,0 +1,56 @@
+import FakeExamsRepository from '../../repositories/fakes/FakeExamsRepository';
+
+import CreateExamService from '../CreateExamService';
+import ListExamsService from '../ListExamsService';
+
+describe('ListExams', () => {
+    const patient1 = {
+        name: "Matheus Aragão",
+        date_of_birth: new Date(),
+        phone_number: "81999998888",
+        cpf: "111.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 30, Pinheiros, Recife",
+        gender: 'female'
+    }
+
+    const patient2 = {
+        name: "Wesley Alves",
+        date_of_birth: new Date(),
+        phone_number: "81988887777",
+        cpf: "22.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 31, Pinheiros, Recife",
+        gender: 'female'
+    }
+
+    it('should be able to attend patient from waiting list', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const createExam = new CreateExamService(
+            fakeExamsRepository,
+        );
+
+        const listExams = new ListExamsService(
+            fakeExamsRepository,
+        );
+
+        await createExam.execute({
+            cpf: patient1.cpf,
+            doctor_name: "Washington",
+            exam: "Eletrocardiograma",
+            scheduled_at: new Date(),
+        });
+
+        await createExam.execute({
+            cpf: patient2.cpf,
+            doctor_name: "Guilherme",
+            exam: "Pneumetria",
+            scheduled_at: new Date(),
+        });
+
+        const exams = await listExams.execute();
+    
+        expect(exams).toHaveLength(2);
+    });
+});

--- a/src/modules/exam/services/__tests__/ShowExamService.spec.ts
+++ b/src/modules/exam/services/__tests__/ShowExamService.spec.ts
@@ -1,0 +1,68 @@
+import AppError from '../../../../shared/errors/AppError';
+
+import FakeExamsRepository from '../../repositories/fakes/FakeExamsRepository';
+
+import CreateExamService from '../CreateExamService';
+import ShowExamService from '../ShowExamService';
+
+describe('ShowExam', () => {
+    const patient1 = {
+        name: "Matheus Aragão",
+        date_of_birth: new Date(),
+        phone_number: "81999998888",
+        cpf: "111.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 30, Pinheiros, Recife",
+        gender: 'female'
+    }
+
+    const patient2 = {
+        name: "Wesley Alves",
+        date_of_birth: new Date(),
+        phone_number: "81988887777",
+        cpf: "22.222.333-44",
+        cep: "20222-222",
+        address: "Rua dos Funkeiros, No 31, Pinheiros, Recife",
+        gender: 'female'
+    }
+
+    it('should be able to show a exam by patient cpf from exams', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const createExam = new CreateExamService(
+            fakeExamsRepository,
+        );
+
+        const showExam = new ShowExamService(
+            fakeExamsRepository,
+        );
+
+        await createExam.execute({ 
+            cpf: patient1.cpf, 
+            doctor_name: "João Gomes",
+            exam: "Ultrassom",
+            scheduled_at: new Date(),
+        });
+        await createExam.execute({ 
+            cpf: patient2.cpf, 
+            doctor_name: "Tarcísio da Acordeon",
+            exam: "Urocultura",
+            scheduled_at: new Date(),
+        });
+
+        const showedExam = await showExam.execute({ cpf: patient2.cpf });
+
+        expect(showedExam.patient_cpf).toEqual(patient2.cpf);
+    });
+
+
+    it('should be able to show a exams thats no exists to patient.', async () => {
+        const fakeExamsRepository = new FakeExamsRepository();
+
+        const showedPatient = new ShowExamService(
+            fakeExamsRepository,
+        );
+
+        expect(showedPatient.execute({ cpf: "CPF-INEXISTENTE" })).rejects.toBeInstanceOf(AppError);
+    });
+});

--- a/src/modules/waitinglist/infra/typeorm/repositories/WaitingListRepository.ts
+++ b/src/modules/waitinglist/infra/typeorm/repositories/WaitingListRepository.ts
@@ -84,7 +84,7 @@ class WaitingListRepository implements IWaitingListRepository {
             query.orderBy('attended', 'DESC');
             query.addOrderBy('created_at', 'DESC');
         } else {
-            query.orderBy('attended', 'ASC');
+            query.orderBy('attended', 'DESC');
             query.addOrderBy('priority', 'DESC');
             query.addOrderBy('waitinglists.created_at', 'DESC');
         }

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -6,6 +6,9 @@ import PatientsRepository from '../../modules/patient/infra/typeorm/repositories
 import IWaitingListRepository from '../../modules/waitinglist/repositories/IWaitingListRepository';
 import WaitingListRepository from '../../modules/waitinglist/infra/typeorm/repositories/WaitingListRepository';
 
+import IExamRepository from '../../modules/exam/repositories/IExamsRepository';
+import ExamsRepository from '../../modules/exam/infra/typeorm/repositories/ExamsRepository';
+
 container.registerSingleton<IPatientsRepository>(
     'PatientsRepository',
     PatientsRepository,
@@ -14,4 +17,9 @@ container.registerSingleton<IPatientsRepository>(
 container.registerSingleton<IWaitingListRepository>(
     'WaitingListRepository',
     WaitingListRepository,
+);
+
+container.registerSingleton<IExamRepository>(
+    'ExamsRepository',
+    ExamsRepository,
 );

--- a/src/shared/infra/http/routes/routes.ts
+++ b/src/shared/infra/http/routes/routes.ts
@@ -2,10 +2,12 @@ import { Router } from 'express';
 
 import patientsRouter from '../../../../modules/patient/infra/http/routes/Patients.routes';
 import waitingListRouter from '../../../../modules/waitinglist/infra/http/routes/WaitingList.routes';
+import examsRouter from '../../../../modules/exam/infra/http/routes/Exam.routes';
 
 const routes = Router();
 
 routes.use('/patients', patientsRouter);
 routes.use('/waiting-list', waitingListRouter);
+routes.use('/exams', examsRouter);
 
 export default routes;

--- a/src/shared/infra/http/server.ts
+++ b/src/shared/infra/http/server.ts
@@ -31,25 +31,6 @@ app.use((err: Error, request: Request, response: Response, _: NextFunction) => {
     });
 });
 
-
-app.use((err: Error, request: Request, response: Response, _: NextFunction) => {
-    if (err instanceof AppError) {
-        return response.status(err.statusCode).json({
-            status: 'error',
-            message: err.message,
-        });
-    }
-  
-    console.error(err);
-  
-    return response.status(500).json({
-        status: 'error',
-        message: 'Internal server error',
-    });
-});
-
-app.use(errors());
-
 app.get("/healthcheck", (_: Request, response: Response) => {
     response.send("ok").status(200)
 });

--- a/src/shared/infra/typeorm/migrations/1651491517476-CreateExam.ts
+++ b/src/shared/infra/typeorm/migrations/1651491517476-CreateExam.ts
@@ -1,0 +1,65 @@
+import {MigrationInterface, QueryRunner, Table, TableForeignKey} from "typeorm";
+
+export class CreateExam1651491517476 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'exams',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        isUnique: true,
+                        generationStrategy: 'uuid',
+                        default: `uuid_generate_v4()`,
+                    },
+                    {
+                        name: 'patient_cpf',
+                        type: 'varchar',
+                        isPrimary: true,
+                        isUnique: true,
+                    },
+                    {
+                        name: 'exam',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'scheduled_at',
+                        type: 'timestamp',
+                    },
+                    {
+                        name: 'doctor_name',
+                        type: 'varchar',
+                    },
+                    {
+                        name: 'created_at',
+                        type: 'timestamp',
+                        default: 'now()',
+                    },
+                    {
+                        name: 'updated_at',
+                        type: 'timestamp',
+                        default: 'now()',
+                    },
+                ],
+            })
+        );
+
+        await queryRunner.createForeignKey("exams", new TableForeignKey({
+            name: "PatientExam",
+            columnNames: ["patient_cpf"],
+            referencedColumnNames: ["cpf"],
+            referencedTableName: "patients",
+            onDelete: "CASCADE",
+            onUpdate: "CASCADE",
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropForeignKey('exams', 'PatientExam')
+        await queryRunner.dropTable('exams');
+    }
+
+}


### PR DESCRIPTION
- Create DTOs to create and remove exams, show and find all exams.
- Create Repository (uncoupled) to database manipulation
- Create a fake Repository (uncoupled) to mock manipulation - Used in unit tests
- Create services to create and remove exams, show by patient cpf and find all exams.
- Create all endpoints to exam domain
- Create unit tests to all services
- Apply all principles (which apply in context) SOLID
  - Liskov
  - Open-Closed
  - Dependency Inversion
  - Single Responsability
  - Interface Segregation (don't apply)